### PR TITLE
fix(logging): keep sprint contents off stdout

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -17,6 +17,14 @@ on:
         type: choice
         options: [daily, weekly]
         default: daily
+      debug:
+        # Report content — ticket titles, owner names, API response bodies — is
+        # logged at DEBUG and therefore absent from a normal run log. Turn this on
+        # to diagnose a failure, then delete the run: it puts the whole sprint back
+        # into the log. Scheduled runs can never set it.
+        description: Log full detail (ticket titles, API bodies) to the run log
+        type: boolean
+        default: false
 
 concurrency:
   group: report-${{ github.workflow }}
@@ -59,6 +67,8 @@ jobs:
 
       - name: Send reports
         env:
+          # Null on a scheduled run, so the schedule always resolves to INFO.
+          LOG_LEVEL: ${{ inputs.debug && 'DEBUG' || 'INFO' }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           JIRA_USER_NAME: ${{ secrets.JIRA_USER_NAME }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,25 @@ GITHUB_REPO=your-github-repo
 
 # Slack Configuration
 SLACK_TOKEN=xoxb-your-slack-bot-token
+
+# Logging (optional) - stdout verbosity, default INFO. See "Logging" below.
+LOG_LEVEL=INFO
 ```
+
+### Logging
+
+Report content — ticket titles, owner names, and API response bodies — is logged at
+`DEBUG`. `INFO` carries only counts and stage markers, so a normal run reads
+`Sent report to 4 users, 46 tickets` rather than listing the sprint.
+
+This split exists because stdout becomes the GitHub Actions run log, which is visible to
+everyone with repository access. `LOG_LEVEL` controls the stdout stream only; the log file
+under `logs/` always records `DEBUG`, so local debugging keeps full detail without widening
+what CI prints.
+
+To get that detail in CI, dispatch the workflow manually with its `debug` input enabled.
+That run's log will contain the full sprint, so delete it afterwards. Scheduled runs cannot
+set the input.
 
 ### Configuration Details
 

--- a/gen_weekly_report.py
+++ b/gen_weekly_report.py
@@ -86,15 +86,18 @@ def main():
 
         # Process each user
         logger.info("Processing weekly reports for all users...")
+        sent_count = 0
         for user_config in JIRA_USERS:
             owner = user_config.get("name")
             slack_user_id = user_config.get("slack_user_id")
             if not owner or not slack_user_id:
-                logger.warning(f"Skipping user {owner} - missing name or slack_user_id")
+                # The name is omitted deliberately: this fires on every run for a
+                # misconfigured entry, and the count is enough to notice it.
+                logger.warning("Skipping a user entry - missing name or slack_user_id")
                 continue
 
-            logger.info(f"Processing weekly report for user: {owner}")
-            
+            logger.debug(f"Processing weekly report for user: {owner}")
+
             user_records = [
                 r for r in notion_records
                 if r.get("owner") == owner and r.get("sprint") in active_sprints
@@ -114,11 +117,14 @@ def main():
             
             success = slack_manager.send_direct_message(message, slack_user_id, slack_token)
             if success:
-                logger.info(f"Weekly report sent successfully to {owner}")
+                sent_count += 1
+                logger.debug(f"Weekly report sent successfully to {owner}")
             else:
+                # Kept at WARNING with the name: a send failure is not routine, and
+                # knowing which recipient failed is the whole diagnostic value.
                 logger.warning(f"Failed to send weekly report to {owner}")
 
-        logger.info("Weekly Report Bot completed successfully")
+        logger.info(f"Weekly Report Bot completed successfully — {sent_count} report(s) sent")
 
     except Exception as e:
         error_message = f"Error occurred in Weekly Report Bot:\n\n*Error Type:* {type(e).__name__}\n*Error Message:* {str(e)}\n*Timestamp:* {logging.Formatter().formatTime(logging.LogRecord('', 0, '', 0, '', (), None))}"

--- a/gen_weekly_report_linear.py
+++ b/gen_weekly_report_linear.py
@@ -92,14 +92,17 @@ def main():
 
         # Process each user
         logger.info("Processing weekly reports for all users...")
+        sent_count = 0
         for user_config in LINEAR_USERS:
             owner = user_config.get("name")
             slack_user_id = user_config.get("slack_user_id")
             if not owner or not slack_user_id:
-                logger.warning(f"Skipping user {owner} - missing name or slack_user_id")
+                # The name is omitted deliberately: this fires on every run for a
+                # misconfigured entry, and the count is enough to notice it.
+                logger.warning("Skipping a user entry - missing name or slack_user_id")
                 continue
 
-            logger.info(f"Processing weekly report for user: {owner}")
+            logger.debug(f"Processing weekly report for user: {owner}")
 
             user_records = [
                 r for r in notion_records
@@ -120,11 +123,14 @@ def main():
 
             success = slack_manager.send_direct_message(message, slack_user_id, slack_token)
             if success:
-                logger.info(f"Weekly report sent successfully to {owner}")
+                sent_count += 1
+                logger.debug(f"Weekly report sent successfully to {owner}")
             else:
+                # Kept at WARNING with the name: a send failure is not routine, and
+                # knowing which recipient failed is the whole diagnostic value.
                 logger.warning(f"Failed to send weekly report to {owner}")
 
-        logger.info("Linear Weekly Report Bot completed successfully")
+        logger.info(f"Linear Weekly Report Bot completed successfully — {sent_count} report(s) sent")
 
     except Exception as e:
         error_message = (

--- a/lib/jira_manager.py
+++ b/lib/jira_manager.py
@@ -69,7 +69,13 @@ class JiraManager:
         
         # Check if response has the expected format
         if "issues" not in data or not isinstance(data["issues"], list):
-            logger.error(f"Unexpected response format: {data}")
+            # Log the shape, not the payload — this branch used to dump the entire
+            # Jira response, every ticket and field in it.
+            logger.error(
+                f"Unexpected response format: {type(data).__name__}, "
+                f"top-level keys={sorted(data.keys()) if isinstance(data, dict) else 'n/a'}"
+            )
+            logger.debug(f"Unexpected Jira response body: {data}")
             raise ValueError("Response does not contain 'issues' list")
         
         # Get unique active sprints from the response
@@ -84,7 +90,8 @@ class JiraManager:
         # Log outputs
         logger.info("="*50)
         logger.debug(f"JQL Query: {jql}")
-        logger.info(f"Active Sprints: {sorted(active_sprints)}")
+        logger.info(f"Active Sprints: {len(active_sprints)}")
+        logger.debug(f"Active sprint names: {sorted(active_sprints)}")
         logger.info(f"Total Issues: {len(data['issues'])}")
         logger.info("="*50)
         
@@ -97,7 +104,9 @@ class JiraManager:
         for issue in data["issues"]:
             # Check if issue has the expected format
             if not isinstance(issue, dict) or "fields" not in issue:
-                logger.warning(f"Skipping issue with unexpected format: {issue}")
+                key = issue.get("key", "unknown") if isinstance(issue, dict) else "unknown"
+                logger.warning(f"Skipping issue with unexpected format: {key}")
+                logger.debug(f"Malformed issue object: {issue}")
                 continue
                 
             fields = issue["fields"]

--- a/lib/linear_manager.py
+++ b/lib/linear_manager.py
@@ -104,8 +104,16 @@ class LinearManager:
         data = response.json()
 
         if "errors" in data:
-            logger.error(f"Linear GraphQL errors: {data['errors']}")
-            raise ValueError(f"Linear API error: {data['errors']}")
+            # Keep the messages, drop locations/path/extensions — those echo the
+            # query and its variables back. The raised message matters just as much
+            # as the logged one: it resurfaces via exc_info at the entry point.
+            messages = "; ".join(
+                str(err.get("message", "unknown")) if isinstance(err, dict) else "unknown"
+                for err in data["errors"]
+            )
+            logger.error(f"Linear GraphQL errors: {messages}")
+            logger.debug(f"Linear GraphQL error detail: {data['errors']}")
+            raise ValueError(f"Linear API error: {messages}")
 
         return data
 
@@ -136,7 +144,8 @@ class LinearManager:
                 active_cycles.add(self._cycle_display_name(node["cycle"]))
 
         logger.info("=" * 50)
-        logger.info(f"Active Cycles: {sorted(active_cycles)}")
+        logger.info(f"Active Cycles: {len(active_cycles)}")
+        logger.debug(f"Active cycle names: {sorted(active_cycles)}")
         logger.info(f"Total Issues: {len(all_nodes)}")
         logger.info("=" * 50)
 
@@ -148,7 +157,8 @@ class LinearManager:
 
         for node in data.get("issues", []):
             if not isinstance(node, dict):
-                logger.warning(f"Skipping unexpected node format: {node}")
+                logger.warning(f"Skipping unexpected node format: {type(node).__name__}")
+                logger.debug(f"Malformed Linear node: {node}")
                 continue
 
             key = node.get("identifier", "")

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -2,19 +2,55 @@ import os
 import logging
 from datetime import datetime
 
+# Report content — ticket titles, owner names, whole API response objects — is
+# logged at DEBUG and must stay there. Anything at INFO or above reaches stdout,
+# and in CI stdout becomes the GitHub Actions run log, so INFO is reserved for
+# counts and stage markers ("Sent report to 4 users, 46 tickets").
+#
+# LOG_LEVEL tunes the stdout stream only, default INFO. The file handler always
+# records DEBUG: logs/ is gitignored and never leaves the machine, so local runs
+# keep full detail without widening what CI prints. To get that detail in CI,
+# dispatch the workflow manually with its `debug` input — a deliberate act, on a
+# run that can be deleted afterwards.
+DEFAULT_STREAM_LEVEL = 'INFO'
+
+_VALID_LEVELS = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+
+# urllib3 logs every request URL at DEBUG, and those URLs carry ticket keys.
+# The root logger sits at DEBUG so the file handler can see everything, which
+# would otherwise pull third-party chatter into both surfaces.
+_NOISY_LOGGERS = ('urllib3', 'requests', 'httpx', 'httpcore', 'notion_client')
+
+
+def resolve_stream_level():
+    """Resolve the stdout log level from LOG_LEVEL, falling back on bad input."""
+    level = os.getenv('LOG_LEVEL', DEFAULT_STREAM_LEVEL).strip().upper()
+    return level if level in _VALID_LEVELS else DEFAULT_STREAM_LEVEL
+
+
 # Configure logging
 def setup_logger():
     # Create logs directory if it doesn't exist
     if not os.path.exists('logs'):
         os.makedirs('logs')
-    
-    # Configure logging
+
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s')
+
     log_filename = f'logs/su_report_{datetime.now().strftime("%Y%m%d")}.log'
+    file_handler = logging.FileHandler(log_filename)
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(getattr(logging, resolve_stream_level()))
+    stream_handler.setFormatter(formatter)
+
+    # Root passes everything through; each handler applies its own threshold.
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
-        handlers=[
-            logging.FileHandler(log_filename),
-            logging.StreamHandler()
-        ]
+        level=logging.DEBUG,
+        handlers=[file_handler, stream_handler],
+        force=True
     )
+
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)

--- a/lib/notion_manager.py
+++ b/lib/notion_manager.py
@@ -79,7 +79,7 @@ class NotionManager:
 
     def get_notion_work_record(self, sprint_name, owner=None):
         """Get work records from Notion database for a specific sprint and optionally filter by owner"""
-        logger.info(f"Getting work records for sprint: {sprint_name}" + (f" and owner: {owner}" if owner else ""))
+        logger.debug(f"Getting work records for sprint: {sprint_name}" + (f" and owner: {owner}" if owner else ""))
         notion_query_url = f"https://api.notion.com/v1/databases/{self.database_id}/query"
         
         # Build filter based on parameters
@@ -230,11 +230,21 @@ class NotionManager:
         return formatted_work_records
 
     def __handle_api_error(self, operation, key, error):
-        """Handle API errors consistently"""
-        error_msg = f"Failed to {operation} {key}"
-        if hasattr(error, 'response') and hasattr(error.response, 'text'):
-            error_msg += f"\nError details: {error.response.text}"
-        logger.error(error_msg)
+        """Handle API errors consistently.
+
+        The response body is the leakiest object in this codebase: a Notion
+        property-validation error echoes back the page properties, ticket title
+        included. ERROR gets the shape (status code, error type); the body itself
+        goes to DEBUG, which reaches the log file but not stdout.
+        """
+        error_msg = f"Failed to {operation} {key} ({type(error).__name__}"
+        response = getattr(error, 'response', None)
+        if response is not None and getattr(response, 'status_code', None) is not None:
+            error_msg += f", HTTP {response.status_code}"
+        logger.error(error_msg + ")")
+
+        if response is not None and hasattr(response, 'text'):
+            logger.debug(f"Failed to {operation} {key} — response body: {response.text}")
 
     def __notion_request_with_retry(self, method, url, **kwargs):
         """Issue a Notion HTTP request, retrying on transient 5xx / 429 errors."""
@@ -370,7 +380,7 @@ class NotionManager:
                 ticket = current_tickets[key]
                 url = f"{self.issue_base_url}/{key}"
 
-                logger.info(f"Updating ticket: {key}")
+                logger.debug(f"Updating ticket: {key}")
 
                 existing_tags = page["properties"].get(PROPERTY_NAMES["TAGS"], {}).get("multi_select", [])
 
@@ -398,7 +408,7 @@ class NotionManager:
             if key in current_pages:
                 continue
             try:
-                logger.info(f"Creating new ticket: {key}")
+                logger.debug(f"Creating new ticket: {key}")
                 url = f"{self.issue_base_url}/{key}"
                 properties = self.__create_properties(
                     key,
@@ -468,11 +478,11 @@ class NotionManager:
 
                 ticket = self.history_ticket_fetcher(key)
                 if ticket is None:
-                    logger.info(f"Skipping update for {key}: Failed to get issue status")
+                    logger.debug(f"Skipping update for {key}: Failed to get issue status")
                     skipped += 1
                     continue
 
-                logger.info(f"Updating history ticket: {key}")
+                logger.debug(f"Updating history ticket: {key}")
 
                 existing_tags = page["properties"].get(PROPERTY_NAMES["TAGS"], {}).get("multi_select", [])
 
@@ -570,7 +580,14 @@ class NotionManager:
             return
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to sync with Notion: {e}")
+            # str(e) on a RequestException carries the full request URL; the type
+            # and status are enough to diagnose, and the rest goes to DEBUG.
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
+            logger.error(
+                f"Failed to sync with Notion: {type(e).__name__}"
+                + (f" (HTTP {status})" if status is not None else "")
+            )
+            logger.debug(f"Notion sync failure detail: {e}")
 
         logger.info("Sync process completed")
 

--- a/lib/slack_manager.py
+++ b/lib/slack_manager.py
@@ -100,7 +100,7 @@ class SlackManager:
             if record.get("sprint") == sprint_name and record.get("owner") == owner
         ]
         
-        self.logger.info(f"Filtered {len(filtered_records)} records for sprint '{sprint_name}' and owner '{owner}'")
+        self.logger.debug(f"Filtered {len(filtered_records)} records for sprint '{sprint_name}' and owner '{owner}'")
         return filtered_records
     
     def _group_records_by_status(self, records: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
@@ -140,14 +140,19 @@ class SlackManager:
         return report_data
     
     def _log_sprint_report(self, report_data: Dict[str, Any], owner: str):
-        """Log sprint report information"""
+        """Log sprint report information.
+
+        Every line here names a person or a ticket, so the whole function logs at
+        DEBUG. The INFO-level trace of a run is the per-user count emitted by the
+        caller — see send_report.
+        """
         sprint_name = report_data["sprint_name"]
         total_records = report_data["total_records"]
-        
-        self.logger.info(f"\n{'='*80}")
-        self.logger.info(f"📊 SPRINT REPORT {sprint_name} - Owner: {owner}")
-        self.logger.info(f"📈 Total records: {total_records}")
-        self.logger.info(f"{'='*80}")
+
+        self.logger.debug(f"\n{'='*80}")
+        self.logger.debug(f"📊 SPRINT REPORT {sprint_name} - Owner: {owner}")
+        self.logger.debug(f"📈 Total records: {total_records}")
+        self.logger.debug(f"{'='*80}")
         
         # Get all records and sort by status
         all_records = []
@@ -163,7 +168,7 @@ class SlackManager:
         
         # Log each record
         for record in all_records:
-            self.logger.info(f"  • {record['ticket_id']}: {record['title']} `{record['status']}`")
+            self.logger.debug(f"  • {record['ticket_id']}: {record['title']} `{record['status']}`")
     
     def send_sprint_report(self, report_data: Dict[str, Any], user_id: str, slack_token: str) -> bool:
         """Send sprint report to Slack via direct message"""
@@ -189,8 +194,12 @@ class SlackManager:
             self.logger.info("No active sprints found in Jira data")
             return []
         
-        self.logger.info(f"Active sprints found: {sorted(active_sprints)}")
-        
+        self.logger.info(f"Active sprints found: {len(active_sprints)}")
+        self.logger.debug(f"Active sprint names: {sorted(active_sprints)}")
+
+        reports_sent = 0
+        users_with_reports = set()
+
         # Process each user
         for user_config in jira_users:
             issue_user_id = user_config.get("issue_user_id")
@@ -199,11 +208,11 @@ class SlackManager:
 
             # Skip if no issue tracker user ID or slack_user_id is empty
             if not issue_user_id or not slack_user_id:
-                self.logger.info(f"Skipping user {owner} - missing issue_user_id or slack_user_id")
+                self.logger.debug(f"Skipping user {owner} - missing issue_user_id or slack_user_id")
                 continue
-                
+
             try:
-                self.logger.info(f"Processing reports for user: {owner}")
+                self.logger.debug(f"Processing reports for user: {owner}")
                 
                 # Process each active sprint for this user
                 for sprint_name in sorted(active_sprints):
@@ -213,11 +222,11 @@ class SlackManager:
                         
                         # Only proceed if filtered records count > 0
                         if sprint_records and len(sprint_records) > 0:
-                            self.logger.info(f"\n{'='*60}")
-                            self.logger.info(f"Processing Sprint: {sprint_name} for user: {owner}")
-                            self.logger.info(f"{'='*60}")
-                            self.logger.info(f"Found {len(sprint_records)} records in Notion for sprint '{sprint_name}', proceeding with report...")
-                            
+                            self.logger.debug(f"\n{'='*60}")
+                            self.logger.debug(f"Processing Sprint: {sprint_name} for user: {owner}")
+                            self.logger.debug(f"{'='*60}")
+                            self.logger.debug(f"Found {len(sprint_records)} records in Notion for sprint '{sprint_name}', proceeding with report...")
+
                             # Create report data
                             report_data = self._create_report_data(sprint_name, sprint_records)
                             
@@ -228,7 +237,9 @@ class SlackManager:
                             self.send_sprint_report(report_data, user_id=slack_user_id, slack_token=slack_token)
                             
                             all_report_data.append(report_data)
-                            
+                            reports_sent += 1
+                            users_with_reports.add(owner)
+
                         # No logging for sprints with no records
                             
                     except Exception as e:
@@ -238,5 +249,8 @@ class SlackManager:
                 self.logger.error(f"Failed to process reports for user {owner}: {e}")
                 continue
         
-        self.logger.info("Sprint report processing completed for all users")
+        self.logger.info(
+            f"Sprint report processing completed — {reports_sent} report(s) "
+            f"sent to {len(users_with_reports)} user(s)"
+        )
         return all_report_data


### PR DESCRIPTION
Implements the plan agreed in #4.

Report content — ticket titles, owner names, whole API response bodies — was logged at
`INFO`, and in CI stdout becomes the Actions run log. Two runs on 2026-07-30 published the
team's cycle publicly as a result.

## What changed

**`lib/logger.py`** — the two handlers had a single hardcoded `INFO`. Each now has its own
threshold: the file handler always records `DEBUG` (`logs/` is gitignored and never leaves
the machine), the stream handler reads `LOG_LEVEL`, default `INFO`. Root drops to `DEBUG` so
records reach the file, so `urllib3` and friends are pinned to `WARNING` — their request URLs
carry ticket keys.

**Content demoted to `DEBUG`** — per-ticket and per-user lines across `slack_manager`,
`notion_manager`, `gen_weekly_report*`. `INFO` now carries counts and stage markers only.
Sprint and cycle names moved too: neither a count nor a marker.

**Error paths log shape, not payload** — demoting `INFO` alone would have missed these, and
they were the larger dumps since they fire at any level:

| Was | Now |
| --- | --- |
| entire Jira response | response type + top-level keys |
| malformed issue object | ticket key |
| malformed Linear node | node type |
| GraphQL errors incl. `extensions` | error messages only |
| Notion `response.text` | exception type + HTTP status |

Each keeps full detail at `DEBUG`. The Linear `raise` is sanitized alongside its log line —
that message resurfaces through `exc_info` at the entry point.

**Tracebacks untouched.** A Python traceback carries file, line, function and source text but
not local variables, so `exc_info` and `logger.exception` keep their diagnostic value without
carrying report content.

**`debug` dispatch input** — sets `LOG_LEVEL=DEBUG` for one manual run, so a failure can still
be diagnosed at full detail deliberately, on a run that can be deleted. Resolves to `INFO` on
a schedule, where `inputs` is null.

## Verification

Exercised every changed call site with sentinel values and asserted on real stdout. Not run
against the live entry points — that would DM the team.

```
ok  : 'SECRET-TITLE-payment-flow-broken' absent from stdout at INFO
ok  : 'SECRET-TITLE-payment-flow-broken' present in log file
ok  : 'secret.owner'                     absent from stdout at INFO
ok  : 'secret.owner'                     present in log file
ok  : 'SECRET-BODY-notion-property-dump' absent from stdout at INFO
ok  : 'SECRET-BODY-notion-property-dump' present in log file
ALL ASSERTIONS PASSED
```

At `INFO` the same paths print only shape:

```
[ERROR]   jira_manager: Unexpected response format: dict, top-level keys=['payload', 'warnings']
[WARNING] jira_manager: Skipping issue with unexpected format: AAA-2
[ERROR]   linear_manager: Linear GraphQL errors: Authentication required
[WARNING] linear_manager: Skipping unexpected node format: str
[ERROR]   notion_manager: Failed to update AAA-3 (SimpleNamespace, HTTP 400)
```

`LOG_LEVEL=DEBUG` reproduces today's full detail.

## Judgement calls worth a look

- **Owner names kept on failure paths** (`Failed to send weekly report to {owner}`) — knowing
  which recipient broke is the whole diagnostic value, and a send failure is not routine. The
  routine "misconfigured user" warning drops the name, since it fires every run.
- **Sprint / cycle names demoted** beyond the table in #4 — they were listed in that issue's
  Evidence section, and the plan's stated principle is counts-and-markers-only at `INFO`.
- **Bare ticket keys** on `notion_manager` error paths are retained: far less sensitive than a
  title, and the minimum needed to diagnose.

## Not covered

- The two 2026-07-30 runs still hold the leaked content. Private now, not deleted — commands
  are in #4, and deleting run history is irreversible.
- Residual risk recorded in #4: an exception *message* can still embed request payload. Not
  observed; worth re-checking against a real failure once the schedule has run a while.
- Whether the repo returns to public is a separate decision, unchanged by this PR.

Closes #4
