### PR TITLE
fix(logging): stop enumerating Jira keys and Slack ids; sanitize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,18 @@ JIRA_USER_NAME=your-jira-username@company.com
 JIRA_API_TOKEN=your-jira-api-token
 
 # Jira Users Configuration (JSON format - single line)
+# Placeholders only. Real account ids and Slack ids belong in .env / repository
+# secrets, never in a tracked file.
 JIRA_USERS=[
   {
-    "name": "charlie.yang",
-    "jira_user_id": "6324466fc7601c8e4ac07788",
-    "slack_user_id": "U03H7Q5A0B0"
+    "name": "first.user",
+    "jira_user_id": "<atlassian-account-id>",
+    "slack_user_id": "<slack-member-id>"
   },
   {
-    "name": "eric.chien",
-    "jira_user_id": "629044a7cf01a10069af1962",
-    "slack_user_id": "U03H7Q5A0B1"
-  },
-  {
-    "name": "fiona.shih",
-    "jira_user_id": "630331b36acf9eeb443d6e27",
-    "slack_user_id": "U03H7Q5A0B2"
+    "name": "second.user",
+    "jira_user_id": "<atlassian-account-id>",
+    "slack_user_id": "<slack-member-id>"
   }
 ]
 
@@ -110,7 +107,7 @@ set the input.
 Each user in `JIRA_USERS` should contain:
 - `name`: Human-readable name for identification
 - `jira_user_id`: Jira user ID (from Jira profile or API)
-- `slack_user_id`: Slack user ID (e.g., U03H7Q5A0B0)
+- `slack_user_id`: Slack member ID (starts with `U`, found in the member's profile)
 
 #### Slack Bot Setup
 1. Create a Slack App at [https://api.slack.com/apps](https://api.slack.com/apps)
@@ -259,17 +256,17 @@ user" is weaker — a sprint boundary legitimately produces zero.
 
 ### Four of five Jira users cannot be messaged — open
 
-`slack_user_id` is an empty string for `eric.chien`, `fiona.shih`,
-`Broccoli Huang` and `Alex Wang` in `JIRA_USERS`, and `send_report` skips any user
-missing it. Even with a working token, only `charlie.yang` would receive a Jira
-report. `eric.chien`'s id is recoverable from his `LINEAR_USERS` entry; the other
-three need a Slack lookup. This is a secret/config edit, not a code change.
+`slack_user_id` is an empty string for four of the five entries in `JIRA_USERS`,
+and `send_report` skips any user missing it. Even with a working token, only one
+user would receive a Jira report. One of the four has an id recoverable from the
+matching `LINEAR_USERS` entry; the other three need a Slack lookup. This is a
+secret/config edit, not a code change.
 
-### harvey.liu is synced but never reported to — open
+### One synced owner is never reported to — open
 
-He owns 123 pages in the Jira Notion database yet is absent from `JIRA_USERS`.
-Adding him needs his Atlassian account id, which cannot be resolved while the
-credential above is dead: user search returns empty and his tickets 404.
+An owner of 123 pages in the Jira Notion database is absent from `JIRA_USERS`.
+Adding them needs their Atlassian account id, which cannot be resolved while the
+credential above is dead: user search returns empty and their tickets 404.
 
 ## Project Structure
 

--- a/lib/notion_manager.py
+++ b/lib/notion_manager.py
@@ -64,6 +64,10 @@ class NotionManager:
         self.jira_token = jira_token
         self.issue_base_url = issue_base_url or f"{JIRA_BASE_URL}/browse"
         self.history_ticket_fetcher = history_ticket_fetcher or self.__get_jira_ticket
+        # HTTP status -> count, for the aggregate emitted at the end of a sync.
+        # Per-ticket fetch failures are DEBUG: a stale backlog produces one line
+        # per archived ticket, which enumerates the whole key space on stdout.
+        self.jira_fetch_failures = {}
         self.notion_headers = {
             "Authorization": notion_token,
             "Content-Type": "application/json",
@@ -349,9 +353,9 @@ class NotionManager:
             active_sprints = [sprint["name"] for sprint in sprints if sprint["state"] == "active"]
             assignee = fields.get("assignee")
             if assignee is None:
-                logger.warning(f"JIRA ticket {key} has no assignee field")
+                logger.debug(f"JIRA ticket {key} has no assignee field")
             if not isinstance(assignee, dict):
-                logger.warning(f"JIRA ticket {key} assignee type is unexpected: {type(assignee).__name__}")
+                logger.debug(f"JIRA ticket {key} assignee type is unexpected: {type(assignee).__name__}")
                 assignee = {}
             
             return {
@@ -363,7 +367,14 @@ class NotionManager:
                 "owner": assignee.get("displayName", "Unassigned")
             }
         except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to get JIRA ticket {key}: {e}")
+            # str(e) embeds the full REST URL, and a stale backlog makes this fire
+            # once per archived ticket — 154 lines on a measured run, which is the
+            # entire key space plus the internal host. The aggregate below carries
+            # the operational signal instead.
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
+            bucket = str(status) if status is not None else type(e).__name__
+            self.jira_fetch_failures[bucket] = self.jira_fetch_failures.get(bucket, 0) + 1
+            logger.debug(f"Failed to get JIRA ticket {key}: {e}")
             return None
 
     def __sync_current_tickets(self, current_pages, jira_data):
@@ -447,6 +458,22 @@ class NotionManager:
         except ValueError:
             logger.warning(f"Unparsable created_time {raw!r}; treating page as in-window")
             return False
+
+    def __log_jira_fetch_failures(self):
+        """Report Jira fetch failures as one aggregate, then reset the tally.
+
+        Keeps the signal an outage needs — "everything is 401" is loud — without
+        naming a ticket per line. Individual keys are at DEBUG.
+        """
+        if not self.jira_fetch_failures:
+            return
+        total = sum(self.jira_fetch_failures.values())
+        breakdown = ", ".join(
+            f"{status}×{count}"
+            for status, count in sorted(self.jira_fetch_failures.items())
+        )
+        logger.error(f"Jira fetch failures: {total} ticket(s) — {breakdown}")
+        self.jira_fetch_failures = {}
 
     def __sync_history_tickets(self, history_pages, jira_data):
         """Sync Notion pages that are not in current sprint with Jira data.
@@ -573,6 +600,7 @@ class NotionManager:
                 f"history: {hist_updated} updated, {hist_skipped} skipped, {hist_failed} failed, "
                 f"{hist_out_of_window} outside the {HISTORY_SYNC_DAYS}-day window"
             )
+            self.__log_jira_fetch_failures()
             if total_failed > 0:
                 logger.warning(f"Sync process completed with {total_failed} failed ticket(s)")
             else:

--- a/lib/slack_manager.py
+++ b/lib/slack_manager.py
@@ -51,7 +51,9 @@ class SlackManager:
                 self.logger.error(f"Failed to send message: {message_data.get('error')}")
                 return False
             
-            self.logger.info(f"Direct message sent to user {user_id} successfully")
+            # A Slack user id identifies a person, and the counts in send_report /
+            # the weekly entry points already say how many messages went out.
+            self.logger.debug(f"Direct message sent to user {user_id} successfully")
             return True
             
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Second pass on #4, driven by what a real private dogfood run actually printed
(`31153710405`).

That run confirmed the first pass worked — no titles, no owner names, no cycle names, no
per-ticket sync lines across 135 + 597 synced tickets — and surfaced three things it missed.

## 1. Jira fetch failures enumerated the key space — my under-scoping

#4 judged that "call sites that log only a ticket key are fine as-is". That was wrong on two
counts: `str(e)` on the `RequestException` embeds the full REST URL including the internal
host, and a stale backlog fires the line once per archived ticket — **154 lines** on the
measured run, covering the entire `BET`/`CET`/`DET` key range.

Per-ticket detail moves to `DEBUG`. The tally is emitted once per sync:

```
[ERROR] Jira fetch failures: 154 ticket(s) — 404×154
```

An outage stays loud (an all-`401` run reads `401×N`) without naming a ticket per line. The
two per-ticket assignee warnings move for the same reason.

## 2. Slack member ids at INFO

`Direct message sent to user U…` printed a member id per message. Those identify people, and
the surrounding counts already report how many went out. Moved to `DEBUG`.

## 3. README carried real data, not examples

Verified against the local `.env`: three **real** Atlassian account ids, one **real** Slack
member id, and six colleagues named across the config block and the known-issues section.
Replaced with placeholders; the known-issues entries keep their operational meaning without
naming anyone.

A sweep of every tracked file against `.env` now returns clean.

## History

The same ids remain in `1a92208`, the commit that introduced them. A full-history sweep found
**no real tokens** — `xoxb-` and `ATATT` hits are all placeholders or prose, and `.env` was
never tracked. Rewriting history was considered and declined: force-pushing does not remove
old commits from GitHub (they stay reachable by SHA), the data has already been publicly
visible for a long stretch, and the rewrite would break the fork, existing clones, and #5's
references.

## Verification

Follows this merge: a second dogfood run while the repository is still private, checked for
the 154 `404` lines and the member ids. Only if that comes back clean do the two 2026-07-30
runs get deleted and the repository go public.
